### PR TITLE
Dockerfile: prometheus_varnish_exporter now releases linux-amd64, not linux-386

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:3.15 as prometheus-exporter-builder
 WORKDIR /build
 RUN apk update
 RUN apk add --quiet ca-certificates curl wget tar gzip jq
-RUN curl -sL https://api.github.com/repos/jonnenauha/prometheus_varnish_exporter/releases/latest | jq -r '.assets[] | select(.name | contains ("linux-386.tar.gz")) | .browser_download_url' | xargs wget -O prometheus_varnish_exporter.linux-386.tar.gz
+RUN curl -sL https://api.github.com/repos/jonnenauha/prometheus_varnish_exporter/releases/latest | jq -r '.assets[] | select(.name | contains ("linux-amd64.tar.gz")) | .browser_download_url' | xargs wget -O prometheus_varnish_exporter.linux-386.tar.gz
 RUN tar -zxvf prometheus_varnish_exporter.linux-386.tar.gz && mv ./prometheus_varnish_exporter-*/prometheus_varnish_exporter /prometheus_varnish_exporter
 
 # Make sure we can run this binary


### PR DESCRIPTION

The releases from `prometheus_varnish_exporter` are named such as 

```text
prometheus_varnish_exporter-1.6.1.linux-amd64.tar.gz
```

.. not "linux-386" as per previous. We need to update the dockerfile so it can download the correct image now.